### PR TITLE
Improve selector match expression

### DIFF
--- a/kubernetes/resource_kubernetes_pod_disruption_budget.go
+++ b/kubernetes/resource_kubernetes_pod_disruption_budget.go
@@ -32,10 +32,51 @@ func resourceKubernetesPodDisruptionBudget() *schema.Resource {
 							ForceNew:    true,
 						},
 						"selector": {
-							Type:        schema.TypeMap,
-							Description: "A label query over pods that should match the Pod Disruption Budget.",
-							Required:    true,
+							Type:        schema.TypeList,
+							Description: "A label query over volumes to consider for binding.",
+							Optional:    true,
 							ForceNew:    true,
+							MaxItems:    1,
+							Elem: &schema.Resource{
+								Schema: map[string]*schema.Schema{
+									"match_expressions": {
+										Type:        schema.TypeList,
+										Description: "A list of label selector requirements. The requirements are ANDed.",
+										Optional:    true,
+										ForceNew:    true,
+										Elem: &schema.Resource{
+											Schema: map[string]*schema.Schema{
+												"key": {
+													Type:        schema.TypeString,
+													Description: "The label key that the selector applies to.",
+													Optional:    true,
+													ForceNew:    true,
+												},
+												"operator": {
+													Type:        schema.TypeString,
+													Description: "A key's relationship to a set of values. Valid operators ard `In`, `NotIn`, `Exists` and `DoesNotExist`.",
+													Optional:    true,
+													ForceNew:    true,
+												},
+												"values": {
+													Type:        schema.TypeSet,
+													Description: "An array of string values. If the operator is `In` or `NotIn`, the values array must be non-empty. If the operator is `Exists` or `DoesNotExist`, the values array must be empty. This array is replaced during a strategic merge patch.",
+													Optional:    true,
+													ForceNew:    true,
+													Elem:        &schema.Schema{Type: schema.TypeString},
+													Set:         schema.HashString,
+												},
+											},
+										},
+									},
+									"match_labels": {
+										Type:        schema.TypeMap,
+										Description: "A map of {key,value} pairs. A single {key,value} in the matchLabels map is equivalent to an element of `match_expressions`, whose key field is \"key\", the operator is \"In\", and the values array contains only \"value\". The requirements are ANDed.",
+										Optional:    true,
+										ForceNew:    true,
+									},
+								},
+							},
 						},
 						"max_unavailable": {
 							Type:        schema.TypeString,

--- a/kubernetes/resource_kubernetes_pod_disruption_budget_test.go
+++ b/kubernetes/resource_kubernetes_pod_disruption_budget_test.go
@@ -21,8 +21,9 @@ func TestAccKubernetesPodDisruptionBudget_minimal(t *testing.T) {
 				Config: testAccKubernetesPodDisruptionBudget_minimal(name),
 				Check: resource.ComposeAggregateTestCheckFunc(
 					resource.TestCheckResourceAttr("kubernetes_pod_disruption_budget.test", "metadata.0.name", name),
-					resource.TestCheckResourceAttr("kubernetes_pod_disruption_budget.test", "spec.0.min_available", "50%"),
-					resource.TestCheckResourceAttr("kubernetes_pod_disruption_budget.test", "spec.0.selector.0.foo", "bar"),
+					resource.TestCheckResourceAttr("kubernetes_pod_disruption_budget.test", "spec.0.selector.0.match_expressions.#", "1"),
+					resource.TestCheckResourceAttr("kubernetes_pod_disruption_budget.test", "spec.0.selector.0.match_expressions.0.key", "foo"),
+					resource.TestCheckResourceAttr("kubernetes_pod_disruption_budget.test", "spec.0.selector.0.match_expressions.0.operator", "Exists"),
 				),
 			},
 		},
@@ -38,9 +39,14 @@ resource "kubernetes_pod_disruption_budget" "test" {
   spec {
     min_available = "50%%"
     selector {
-      foo = "bar"
-    }
+      match_expressions {
+      	key = "foo"
+      	operator = "Exists"
+      }
+	}
   }
 }
 `, name)
 }
+
+


### PR DESCRIPTION
This is primarily to allow us to define selectors with only keys & no values set but will make defining PDB more flexible.

Main change is that 'selector' is now a TypeList that can have 
match_labels (TypeMap, as selector was before) OR 
match_expressions (a TypeList with properties: key, operator & value)
properties set

Updated relevant flatten & expand functions that map the PDB Spec config & updated relevant tests.